### PR TITLE
Use also `run_test.sh` from CWL repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,13 @@ language: go
 go:
     - 1.8
     - tip
+python:
+    - 3.6
 before_script:
     - go get ./...
+    - go install
+    - pip install cwltest
+    - git clone https://github.com/common-workflow-language/common-workflow-language.git
 script:
     - go test ./... -v
+    - cd common-workflow-language && ./run_test.sh RUNNER=yacle


### PR DESCRIPTION
should be tested by [run_test.sh](https://github.com/common-workflow-language/common-workflow-language/blob/master/run_test.sh) provided by CWL.

Related: https://github.com/common-workflow-language/common-workflow-language/issues/483

Caution: This pull-request promotes TDD, it means NOT all the tests pass for now.