### PR TITLE
Add test case -n111

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_script:
     - go install
     - pip install --user cwltest
 script:
-    - ./cwl/run_test.sh RUNNER=yacle -n1,2,3,4,5,7,8,9,10,11,12,49
+    - ./cwl/run_test.sh RUNNER=yacle -n1,2,3,4,5,7,8,9,10,11,12,49,111


### PR DESCRIPTION
`File` supports `contents` if `File` does not have `location` and `path`

Specification is here
[Common Workflow Language (CWL) Command Line Tool Description, v1.0.2](https://www.commonwl.org/v1.0/CommandLineTool.html#File)

Related commit is

[Support File Contents · otiai10/cwl\.go@0dc5c2f](https://github.com/otiai10/cwl.go/commit/0dc5c2ffbb3ae49f45d4296220782053bdcc7f58)
